### PR TITLE
updating the color properties from weak to strong

### DIFF
--- a/MZLoading/MZLoadingCircle.h
+++ b/MZLoading/MZLoadingCircle.h
@@ -20,8 +20,8 @@ CustomLayer2 *customLayer2_;
 CustomLayer3 *customLayer3_;
 }
 
-@property (weak,nonatomic) UIColor *colorCustomLayer;
-@property (weak,nonatomic) UIColor *colorCustomLayer2;
-@property (weak,nonatomic) UIColor *colorCustomLayer3;
+@property (strong,nonatomic) UIColor *colorCustomLayer;
+@property (strong,nonatomic) UIColor *colorCustomLayer2;
+@property (strong,nonatomic) UIColor *colorCustomLayer3;
 
 @end


### PR DESCRIPTION
the color properties should be retained as you are not sure if the caller is also assigning auto-released UIColor objects. in 64-bit devices, this issue is visible, the colors objects are releasing before the layer draws itself, so the loading circles always show black.
